### PR TITLE
New fix for Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM php:7.0-apache
 COPY . /var/www/html/
 WORKDIR /var/www/html
 
-RUN apt-get update && apt-get install -y git
+RUN apt-get update && apt-get install -y git zip unzip
 
 RUN curl -sS https://getcomposer.org/installer | php
 RUN ./composer.phar install


### PR DESCRIPTION
Composer can't unzip the files if unzip is not installed.
