### PR TITLE
Update Dockerfile to use a vulnerable PHP version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.0-apache
+FROM php:7.0.8-apache
 
 COPY . /var/www/html/
 WORKDIR /var/www/html


### PR DESCRIPTION
According to the [PHP releases notes](https://secure.php.net/ChangeLog-7.php), HTTPOXY was fixed in 7.0.9, so using 7.0.8 here will make sure the vulnerability can be demonstrated using this.
